### PR TITLE
Release

### DIFF
--- a/src/components/BookCard/BookCard.tsx
+++ b/src/components/BookCard/BookCard.tsx
@@ -65,8 +65,8 @@ export const BookCard = React.memo(
             <Image
               src={coverImage}
               alt={book.title}
-              width={240}
-              height={360}
+              width={horizontal ? 128 : 240}
+              height={horizontal ? 192 : 360}
               className={cn(
                 'rounded-md border border-gray-200 bg-gray-100 object-cover transition-transform group-hover:scale-[1.02]',
                 horizontal ? 'h-auto w-full' : 'h-full w-full object-center'
@@ -83,7 +83,7 @@ export const BookCard = React.memo(
               onError={e => {
                 // 이미지 로드 실패 시 기본 이미지로 대체
                 const target = e.currentTarget as HTMLImageElement;
-                target.src = `https://placehold.co/240x360/f3f4f6/9ca3af?text=${encodeURIComponent(book.title.slice(0, 10))}`;
+                target.src = `https://placehold.co/${horizontal ? '128x192' : '240x360'}/f3f4f6/9ca3af?text=${encodeURIComponent(book.title.slice(0, 10))}`;
               }}
             />
           </div>


### PR DESCRIPTION
- NextJS Image 컴포넌트에 명시적인 width/height props 추가
- 일반 모드: 240x360 (3:4.5 비율), horizontal 모드: 128x192
- 이미지 로딩 전 공간 예약으로 레이아웃 시프트 방지
- 모바일에서 페이지 간 이동 시 스크롤 위치 틀어짐 문제 해결
- onError 핸들러의 placeholder 이미지 크기도 동적으로 설정