### PR TITLE
Release

### DIFF
--- a/src/app/discover/components/CategoryFilter.tsx
+++ b/src/app/discover/components/CategoryFilter.tsx
@@ -91,9 +91,6 @@ export const CategoryFilter = ({ className }: CategoryFilterProps) => {
         subcategory: undefined,
       });
     }
-
-    // 스크롤을 맨 위로 이동
-    window.scrollTo({ top: 0 });
   };
 
   const handleSubcategoryClick = (subcategoryId: string) => {
@@ -110,9 +107,6 @@ export const CategoryFilter = ({ className }: CategoryFilterProps) => {
         subcategory: undefined,
       });
     }
-
-    // 스크롤을 맨 위로 이동
-    window.scrollTo({ top: 0, behavior: 'smooth' });
   };
 
   // 카테고리별 색상 가져오기

--- a/src/app/discover/components/DiscoverSortDropdown.tsx
+++ b/src/app/discover/components/DiscoverSortDropdown.tsx
@@ -49,9 +49,6 @@ export function DiscoverSortDropdown({ className }: DiscoverSortDropdownProps) {
         // 기본값인 경우 URL에서 제거
         updateQueryParams({ sort: undefined });
       }
-
-      // 스크롤을 맨 위로 이동
-      window.scrollTo({ top: 0 });
     }
   };
 
@@ -72,16 +69,10 @@ export function DiscoverSortDropdown({ className }: DiscoverSortDropdownProps) {
         // 기본값인 경우 URL에서 제거
         updateQueryParams({ timeRange: undefined });
       }
-
-      // 스크롤을 맨 위로 이동
-      window.scrollTo({ top: 0, behavior: 'smooth' });
     } else {
       setTimeRange(DEFAULT_TIME_RANGE);
       // 기본값으로 설정된 경우 URL에서 제거
       updateQueryParams({ timeRange: undefined });
-
-      // 스크롤을 맨 위로 이동
-      window.scrollTo({ top: 0, behavior: 'smooth' });
     }
   };
 

--- a/src/app/discover/page.tsx
+++ b/src/app/discover/page.tsx
@@ -165,6 +165,13 @@ export default function DiscoverPage() {
     setSortOption(sort);
     setTimeRange(timeRange);
     if (bookId) setSelectedBookId(bookId);
+
+    // 필터나 정렬이 변경되었을 때 스크롤 위치를 맨 위로 이동
+    // 초기 로드가 아닌 경우에만 스크롤 이동
+    const isInitialLoad = !searchParams.toString();
+    if (!isInitialLoad) {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    }
   }, [
     searchParams,
     updateQueryParams,

--- a/src/app/libraries/hooks/useLibraries.ts
+++ b/src/app/libraries/hooks/useLibraries.ts
@@ -142,8 +142,6 @@ export function useLibraries(): UseLibrariesResult {
   const handleSortChange = useCallback(
     (sortId: string) => {
       setSortOption(sortId);
-      // 스크롤을 맨 위로 이동
-      window.scrollTo({ top: 0 });
     },
     [setSortOption]
   );
@@ -151,8 +149,6 @@ export function useLibraries(): UseLibrariesResult {
   const handleTimeRangeChange = useCallback(
     (newTimeRange: TimeRangeOptions) => {
       setTimeRange(newTimeRange);
-      // 스크롤을 맨 위로 이동
-      window.scrollTo({ top: 0 });
     },
     [setTimeRange]
   );
@@ -160,8 +156,6 @@ export function useLibraries(): UseLibrariesResult {
   const handleSearchChange = useCallback(
     (value: string) => {
       setSearchQuery(value);
-      // 스크롤을 맨 위로 이동
-      window.scrollTo({ top: 0, behavior: 'smooth' });
     },
     [setSearchQuery]
   );

--- a/src/app/libraries/page.tsx
+++ b/src/app/libraries/page.tsx
@@ -62,6 +62,13 @@ export default function LibrariesPage() {
     } else {
       setSearchQuery('');
     }
+
+    // 필터나 정렬이 변경되었을 때 스크롤 위치를 맨 위로 이동
+    // 초기 로드가 아닌 경우에만 스크롤 이동
+    const isInitialLoad = !searchParams.toString();
+    if (!isInitialLoad) {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    }
   }, [searchParams, setTagFilter, setSortOption, setTimeRange, setSearchQuery]);
 
   return (

--- a/src/app/popular/components/CategoryFilter.tsx
+++ b/src/app/popular/components/CategoryFilter.tsx
@@ -59,9 +59,6 @@ export const CategoryFilter = ({ className }: CategoryFilterProps) => {
         subcategory: undefined,
       });
     }
-
-    // 스크롤을 맨 위로 이동
-    window.scrollTo({ top: 0 });
   };
 
   const handleSubcategoryClick = (subcategoryId: string) => {
@@ -78,9 +75,6 @@ export const CategoryFilter = ({ className }: CategoryFilterProps) => {
         subcategory: undefined,
       });
     }
-
-    // 스크롤을 맨 위로 이동
-    window.scrollTo({ top: 0, behavior: 'smooth' });
   };
 
   return (

--- a/src/app/popular/components/PopularSortDropdown.tsx
+++ b/src/app/popular/components/PopularSortDropdown.tsx
@@ -46,9 +46,6 @@ export function PopularSortDropdown({ className }: PopularSortDropdownProps) {
         // 기본값인 경우 URL에서 제거
         updateQueryParams({ sort: undefined });
       }
-
-      // 스크롤을 맨 위로 이동
-      window.scrollTo({ top: 0 });
     }
   };
 
@@ -69,16 +66,10 @@ export function PopularSortDropdown({ className }: PopularSortDropdownProps) {
         // 기본값인 경우 URL에서 제거
         updateQueryParams({ timeRange: undefined });
       }
-
-      // 스크롤을 맨 위로 이동
-      window.scrollTo({ top: 0, behavior: 'smooth' });
     } else {
       setTimeRange(DEFAULT_TIME_RANGE);
       // 기본값으로 설정된 경우 URL에서 제거
       updateQueryParams({ timeRange: undefined });
-
-      // 스크롤을 맨 위로 이동
-      window.scrollTo({ top: 0, behavior: 'smooth' });
     }
   };
 

--- a/src/app/popular/page.tsx
+++ b/src/app/popular/page.tsx
@@ -185,6 +185,13 @@ export default function PopularPage() {
     setSortOption(sort);
     setTimeRange(timeRange);
     if (bookId) setSelectedBookId(bookId);
+
+    // 필터나 정렬이 변경되었을 때 스크롤 위치를 맨 위로 이동
+    // 초기 로드가 아닌 경우에만 스크롤 이동
+    const isInitialLoad = !searchParams.toString();
+    if (!isInitialLoad) {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    }
   }, [
     searchParams,
     updateQueryParams,


### PR DESCRIPTION
- 분야별 인기, 발견하기, 서재 페이지에서 필터/정렬 변경 시 스크롤을 맨 위로 이동
- 핸들러에서 스크롤 처리를 제거하고 useEffect에서 쿼리 파라미터 변경 감지 시 처리
- 초기 로드가 아닌 경우에만 스크롤 이동하도록 조건 추가
- behavior: 'smooth' 옵션으로 부드러운 스크롤 애니메이션 적용