### PR TITLE
Release

### DIFF
--- a/src/app/library/[id]/components/LibrarySidebar/LibrarySidebarUpdates.tsx
+++ b/src/app/library/[id]/components/LibrarySidebar/LibrarySidebarUpdates.tsx
@@ -26,8 +26,8 @@ export const LibrarySidebarUpdates: FC<LibrarySidebarUpdatesProps> = ({
       });
     }
 
-    // 3일 이후는 절대시간 표시 (시간 제외)
-    return format(new Date(date), 'PPP', { locale: ko });
+    // 3일 이후는 절대시간 표시 (날짜 + 시간)
+    return format(new Date(date), 'PPP p', { locale: ko });
   };
 
   // 가장 최근 업데이트

--- a/src/components/BookDialog/BookReviews.tsx
+++ b/src/components/BookDialog/BookReviews.tsx
@@ -72,8 +72,8 @@ export const formatSmartDate = (dateStr: string) => {
       return formatDistanceToNow(date, { addSuffix: true, locale: ko });
     }
 
-    // 3일 이후는 절대시간 표시 (시간 제외)
-    return format(date, 'PPP', { locale: ko });
+    // 3일 이후는 절대시간 표시 (날짜 + 시간)
+    return format(date, 'PPP p', { locale: ko });
   } catch {
     return dateStr;
   }

--- a/src/components/ReviewCard/utils.tsx
+++ b/src/components/ReviewCard/utils.tsx
@@ -73,8 +73,8 @@ export const formatRelativeDate = (dateStr: string | Date): string => {
     return formatDistanceToNow(date, { addSuffix: true, locale: ko });
   }
 
-  // 3일 이후는 절대시간 표시 (시간 제외)
-  return format(date, 'PPP', { locale: ko });
+  // 3일 이후는 절대시간 표시 (날짜 + 시간)
+  return format(date, 'PPP p', { locale: ko });
 };
 
 // 리뷰 타입 이름 가져오기


### PR DESCRIPTION
- 3일 이내: 상대시간 표시 (예: "2시간 전")
- 3일 이후: 절대시간 + 시간 표시 (예: "2024년 3월 10일 오후 2:30")
- 리뷰, 댓글, 라이브러리 업데이트 모든 시간 표시에 적용
- PPP p 포맷을 사용하여 날짜와 시간을 모두 포함
- 사용자가 정확한 시간 정보를 확인할 수 있도록 개선