### PR TITLE
Release

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@radix-ui/react-alert-dialog": "^1.1.7",
     "@radix-ui/react-avatar": "^1.1.3",
     "@radix-ui/react-checkbox": "^1.1.4",
+    "@radix-ui/react-collapsible": "^1.1.11",
     "@radix-ui/react-dialog": "^1.1.10",
     "@radix-ui/react-dropdown-menu": "^2.1.6",
     "@radix-ui/react-label": "^2.1.2",

--- a/src/app/library/[id]/components/LibraryContent/LibraryContent.tsx
+++ b/src/app/library/[id]/components/LibraryContent/LibraryContent.tsx
@@ -3,7 +3,6 @@ import { LibraryListItem } from '@/apis/library/types';
 import { Separator } from '@/components/ui/separator';
 import { useBookDetailOpen } from '@/hooks/useBookDetailOpen';
 import { useCurrentUser } from '@/hooks/useCurrentUser';
-import { decodeHtmlEntities } from '@/lib/utils';
 import { useParams } from 'next/navigation';
 import { useState } from 'react';
 import { useLibraryDetail } from '../../hooks';
@@ -88,13 +87,6 @@ export function LibraryContent() {
 
   return (
     <div className="space-y-3">
-      {/* 서재 설명 */}
-      <div className="rounded-xl bg-white py-2">
-        <p className="text-gray-700">
-          {decodeHtmlEntities(library.description || '설명이 없습니다.')}
-        </p>
-      </div>
-
       <Separator className="border-gray-100" />
 
       {/* 책 목록 */}

--- a/src/app/library/[id]/components/LibraryHeader/LibraryHeaderOwnerInfo.tsx
+++ b/src/app/library/[id]/components/LibraryHeader/LibraryHeaderOwnerInfo.tsx
@@ -10,10 +10,5 @@ interface LibraryHeaderOwnerInfoProps {
 export const LibraryHeaderOwnerInfo: FC<LibraryHeaderOwnerInfoProps> = ({
   owner,
 }) => {
-  return (
-    <p className="text-sm text-gray-500">
-      <span className="font-medium text-gray-700">{owner.username}</span>
-      님의 서재
-    </p>
-  );
+  return null;
 };

--- a/src/app/library/[id]/components/LibraryHeader/LibraryHeaderTitle.tsx
+++ b/src/app/library/[id]/components/LibraryHeader/LibraryHeaderTitle.tsx
@@ -15,15 +15,35 @@ export const LibraryHeaderTitle: FC<LibraryHeaderTitleProps> = ({
   hasTags,
 }) => {
   return (
-    <div className="mb-2 flex flex-wrap items-center gap-3">
-      <h1 className="text-2xl font-bold text-gray-900">{library.name}</h1>
+    <div className="mb-2">
+      <div className="mb-1 flex items-center gap-3">
+        <h1 className="text-2xl font-bold text-gray-900">{library.name}</h1>
+
+        {/* 공개/비공개 배지는 소유자에게만 표시 - 타이틀 바로 우측에 배치 */}
+        {isOwner && library && (
+          <LibraryHeaderVisibilityBadge isPublic={library.isPublic} />
+        )}
+      </div>
+
+      {/* 서재 설명 - 모바일에서 타이틀 바로 아래에 표시 */}
+      <div className="mb-3 lg:hidden">
+        {library.description ? (
+          <div className="relative overflow-hidden rounded-xl border border-blue-100 bg-gradient-to-r from-blue-50 to-indigo-50 p-4 shadow-sm">
+            <div className="absolute top-0 left-0 h-full w-1 bg-gradient-to-b from-blue-400 to-indigo-500"></div>
+            <p className="pl-2 text-sm leading-relaxed font-medium text-gray-700">
+              {library.description}
+            </p>
+          </div>
+        ) : (
+          <div className="text-sm text-gray-500">설명이 없습니다</div>
+        )}
+      </div>
 
       {/* 서재 태그 */}
-      {hasTags && library.tags && <LibraryHeaderTags tags={library.tags} />}
-
-      {/* 공개/비공개 배지는 소유자에게만 표시 */}
-      {isOwner && library && (
-        <LibraryHeaderVisibilityBadge isPublic={library.isPublic} />
+      {hasTags && library.tags && (
+        <div className="flex flex-wrap items-center gap-3">
+          <LibraryHeaderTags tags={library.tags} />
+        </div>
       )}
     </div>
   );

--- a/src/app/library/[id]/components/LibrarySidebar/LibrarySidebarUpdates.tsx
+++ b/src/app/library/[id]/components/LibrarySidebar/LibrarySidebarUpdates.tsx
@@ -1,8 +1,13 @@
 import { UpdateHistoryItem } from '@/apis/library/types';
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible';
 import { differenceInDays, format, formatDistanceToNow } from 'date-fns';
 import { ko } from 'date-fns/locale';
-import { Clock } from 'lucide-react';
-import { FC, ReactNode } from 'react';
+import { ChevronDown, Clock } from 'lucide-react';
+import { FC, ReactNode, useState } from 'react';
 
 interface LibrarySidebarUpdatesProps {
   updates: UpdateHistoryItem[];
@@ -13,6 +18,8 @@ export const LibrarySidebarUpdates: FC<LibrarySidebarUpdatesProps> = ({
   updates,
   renderActivityMessage,
 }) => {
+  const [isOpen, setIsOpen] = useState(false);
+
   // 스마트 시간 포맷팅 (3일 이내는 상대시간, 이후는 절대시간)
   const formatSmartTime = (date: Date): string => {
     const now = new Date();
@@ -69,11 +76,28 @@ export const LibrarySidebarUpdates: FC<LibrarySidebarUpdatesProps> = ({
 
   return (
     <div className="rounded-xl bg-gray-50 p-4">
-      <div className="mb-3 flex items-center">
-        <Clock className="mr-1.5 h-4 w-4 text-gray-500" />
-        <h3 className="text-sm font-medium text-gray-900">최근 활동</h3>
-      </div>
-      <div className="space-y-2">{renderRecentUpdates()}</div>
+      <Collapsible open={isOpen} onOpenChange={setIsOpen}>
+        <CollapsibleTrigger className="-m-2 flex w-full items-center justify-between rounded-lg p-2 hover:bg-gray-100 lg:m-0 lg:cursor-default lg:p-0 lg:hover:bg-transparent">
+          <div className="flex items-center">
+            <Clock className="mr-1.5 h-4 w-4 text-gray-500" />
+            <h3 className="text-sm font-medium text-gray-900">최근 활동</h3>
+          </div>
+          <ChevronDown
+            className={`h-4 w-4 text-gray-500 lg:hidden ${
+              isOpen ? 'rotate-180 text-gray-700' : 'text-gray-400'
+            }`}
+          />
+        </CollapsibleTrigger>
+
+        {/* 데스크톱에서는 항상 표시, 모바일에서는 Collapsible */}
+        <div className="hidden lg:block">
+          <div className="mt-2 space-y-2">{renderRecentUpdates()}</div>
+        </div>
+
+        <CollapsibleContent className="lg:hidden">
+          <div className="mt-3 space-y-2">{renderRecentUpdates()}</div>
+        </CollapsibleContent>
+      </Collapsible>
     </div>
   );
 };

--- a/src/components/ui/collapsible.tsx
+++ b/src/components/ui/collapsible.tsx
@@ -1,0 +1,31 @@
+import * as CollapsiblePrimitive from '@radix-ui/react-collapsible';
+
+function Collapsible({
+  ...props
+}: React.ComponentProps<typeof CollapsiblePrimitive.Root>) {
+  return <CollapsiblePrimitive.Root data-slot="collapsible" {...props} />;
+}
+
+function CollapsibleTrigger({
+  ...props
+}: React.ComponentProps<typeof CollapsiblePrimitive.CollapsibleTrigger>) {
+  return (
+    <CollapsiblePrimitive.CollapsibleTrigger
+      data-slot="collapsible-trigger"
+      {...props}
+    />
+  );
+}
+
+function CollapsibleContent({
+  ...props
+}: React.ComponentProps<typeof CollapsiblePrimitive.CollapsibleContent>) {
+  return (
+    <CollapsiblePrimitive.CollapsibleContent
+      data-slot="collapsible-content"
+      {...props}
+    />
+  );
+}
+
+export { Collapsible, CollapsibleContent, CollapsibleTrigger };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1771,6 +1771,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@radix-ui/react-collapsible@npm:^1.1.11":
+  version: 1.1.11
+  resolution: "@radix-ui/react-collapsible@npm:1.1.11"
+  dependencies:
+    "@radix-ui/primitive": "npm:1.1.2"
+    "@radix-ui/react-compose-refs": "npm:1.1.2"
+    "@radix-ui/react-context": "npm:1.1.2"
+    "@radix-ui/react-id": "npm:1.1.1"
+    "@radix-ui/react-presence": "npm:1.1.4"
+    "@radix-ui/react-primitive": "npm:2.1.3"
+    "@radix-ui/react-use-controllable-state": "npm:1.2.2"
+    "@radix-ui/react-use-layout-effect": "npm:1.1.1"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 10c0/fa2de539ef06e2b2d18acebb12a34ce1534ca88bd484b7359aac05534d1e551fe83eaafbf60915c00161bb370f0dc9fc303903133510dea0a59fd018155b7db5
+  languageName: node
+  linkType: hard
+
 "@radix-ui/react-collection@npm:1.1.2":
   version: 1.1.2
   resolution: "@radix-ui/react-collection@npm:1.1.2"
@@ -2506,6 +2532,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@radix-ui/react-presence@npm:1.1.4":
+  version: 1.1.4
+  resolution: "@radix-ui/react-presence@npm:1.1.4"
+  dependencies:
+    "@radix-ui/react-compose-refs": "npm:1.1.2"
+    "@radix-ui/react-use-layout-effect": "npm:1.1.1"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 10c0/8202647139d6f5097b0abcc43dfba471c00b69da95ca336afe3ea23a165e05ca21992f40fc801760fe442f3e064e54e2f2cbcb9ad758c4b07ef6c69a5b6777bd
+  languageName: node
+  linkType: hard
+
 "@radix-ui/react-primitive@npm:2.0.2, @radix-ui/react-primitive@npm:^2.0.2":
   version: 2.0.2
   resolution: "@radix-ui/react-primitive@npm:2.0.2"
@@ -2560,6 +2606,25 @@ __metadata:
     "@types/react-dom":
       optional: true
   checksum: 10c0/b436280dbd705b8b32f66b2a36a6432d90db579191fd283697d5d6a4b661ac4ee86b0f6a05e223806ce0802b2652dd8d95c6f7e0ce3c0a5567b2b1e2c3a3fcfe
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-primitive@npm:2.1.3":
+  version: 2.1.3
+  resolution: "@radix-ui/react-primitive@npm:2.1.3"
+  dependencies:
+    "@radix-ui/react-slot": "npm:1.2.3"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 10c0/fdff9b84913bb4172ef6d3af7442fca5f9bba5f2709cba08950071f819d7057aec3a4a2d9ef44cf9cbfb8014d02573c6884a04cff175895823aaef809ebdb034
   languageName: node
   linkType: hard
 
@@ -2730,6 +2795,21 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10c0/f1455f36479e87a0a2254fc2e2b2aba6740d1fbcada949071210bf2a009a031ad508ac01b544bce96337bcca82f49531b46c71615141a5985aaa11ae69b967b1
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-slot@npm:1.2.3":
+  version: 1.2.3
+  resolution: "@radix-ui/react-slot@npm:1.2.3"
+  dependencies:
+    "@radix-ui/react-compose-refs": "npm:1.1.2"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/5913aa0d760f505905779515e4b1f0f71a422350f077cc8d26d1aafe53c97f177fec0e6d7fbbb50d8b5e498aa9df9f707ca75ae3801540c283b26b0136138eef
   languageName: node
   linkType: hard
 
@@ -6440,6 +6520,7 @@ __metadata:
     "@radix-ui/react-alert-dialog": "npm:^1.1.7"
     "@radix-ui/react-avatar": "npm:^1.1.3"
     "@radix-ui/react-checkbox": "npm:^1.1.4"
+    "@radix-ui/react-collapsible": "npm:^1.1.11"
     "@radix-ui/react-dialog": "npm:^1.1.10"
     "@radix-ui/react-dropdown-menu": "npm:^2.1.6"
     "@radix-ui/react-label": "npm:^2.1.2"


### PR DESCRIPTION
- 서재 제목 우측에 공개/비공개 태그 배치 (모바일/데스크톱 공통)
- '설명이 없습니다' 중복 표시 문제 해결 (LibraryContent에서 제거)
- 'bong님의 서재' 텍스트 제거로 UI 간소화
- 모바일에서 서재 설명을 타이틀 바로 아래로 재배치
- 최근활동에서 불필요한 애니메이션 제거 (Collapsible 유지)
- Collapsible 컴포넌트 추가 및 모바일 최적화
- 설명 텍스트 기울임체 스타일 제거로 일관성 개선